### PR TITLE
Update band template to fix off-centered Contact section

### DIFF
--- a/templates/band.html
+++ b/templates/band.html
@@ -272,8 +272,8 @@
         </div>
     </section>
 
-    <section class="section columns">
-        <div class="container has-text-centered column is-10 is-offset-1">
+    <section class="section">
+        <div class="container has-text-centered">
             <h2 class="title">Contact</h2>
 
             <form>


### PR DESCRIPTION
The Contact section is off-centered at larger screen sizes (1440x956 and 2560x956). By removing the column grid classes the Contact section can be centered properly.

You can see screenshots of the off center Contact section and screenshots of the fix applied below:
- [Off center Contact Section 1440x956 px](https://user-images.githubusercontent.com/9725825/47674860-b008b600-db8e-11e8-9eae-a1452aa0a06d.png)
- [Off center Contact Section 2560x956 px](https://user-images.githubusercontent.com/9725825/47674861-b008b600-db8e-11e8-893f-9bfb568c00c4.png)
- [Fix applied Contact section 1440x956px](https://user-images.githubusercontent.com/9725825/47674857-b008b600-db8e-11e8-8d45-f9f20befba44.png)
- [Fix applied Contact section 2560x956](https://user-images.githubusercontent.com/9725825/47674858-b008b600-db8e-11e8-9a57-f6ad72675d40.png)

Screenshots taken in Chrome browser



