### PR TITLE
Additional Column Sizes on template page for different breakpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <div class="container content-wrapper">
       <div class="columns is-multiline">
         <!-- admin -->
-        <div class="column is-3 desktop-only">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -58,7 +58,7 @@
           </div>
         </div>
         <!-- band -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -84,7 +84,7 @@
           </div>
         </div>
         <!-- blog -->
-        <div class="column is-3 desktop-only">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -110,7 +110,7 @@
           </div>
         </div>
         <!-- cards -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -136,7 +136,7 @@
           </div>
         </div>
         <!-- cheatsheet -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -162,7 +162,7 @@
           </div>
         </div>
         <!-- cover -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -188,7 +188,7 @@
           </div>
         </div>
         <!-- forum -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -214,7 +214,7 @@
           </div>
         </div>
         <!-- hero -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -240,7 +240,7 @@
           </div>
         </div>
         <!--inbox -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -266,7 +266,7 @@
           </div>
         </div>
         <!-- insta album -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -292,7 +292,7 @@
           </div>
         </div>
         <!--kanban -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -317,7 +317,7 @@
             </footer>
           </div>
         </div>
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -343,7 +343,7 @@
           </div>
         </div>
         <!-- landing -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -369,7 +369,7 @@
           </div>
         </div>
         <!-- login -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -395,7 +395,7 @@
           </div>
         </div>
         <!-- modal cards -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -421,7 +421,7 @@
           </div>
         </div>
         <!-- Personal/Portfolio template -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -447,7 +447,7 @@
           </div>
         </div>
         <!-- Personal/Portfolio template -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -473,7 +473,7 @@
           </div>
         </div>
         <!-- tabs -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">
@@ -499,7 +499,7 @@
           </div>
         </div>
         <!-- Contact Page -->
-        <div class="column is-3">
+        <div class="column is-4-desktop is-3-widescreen is-half-tablet">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title">


### PR DESCRIPTION
I've added a few additional responsive column sizes to make the thumbnails easier to view at the different breakpoints:
* half columns for tablet
* third columns for desktop
* quarter columns for widescreen and above