### PR TITLE
Update broken bulma.css CDN links in templates

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <title>bulma cards</title>
     <link rel="shortcut icon" href="../images/fav_icon.png" type="image/x-icon">
-    <link rel='stylesheet prefetch' href='https://cdnjs.cloudflare.com/ajax/libs/bulma/0.8.0/css/bulma.css'>
+    <link rel="stylesheet" href="https://unpkg.com/bulma@0.8.0/css/bulma.min.css" />
     <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link rel="stylesheet" href="../css/cards.css">
 

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -8,7 +8,7 @@
 	<title>Contact Form - Free Bulma template</title>
 	<link rel="shortcut icon" href="../images/fav_icon.png" type="image/x-icon">
 	<!-- Bulma Version 0.8.x-->
-	<link rel='stylesheet prefetch' href='https://cdnjs.cloudflare.com/ajax/libs/bulma/0.8.0/css/bulma.css'>
+	<link rel="stylesheet" href="https://unpkg.com/bulma@0.8.0/css/bulma.min.css" />
 	<link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
 		integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 	<link rel="stylesheet" href="../css/contact.css">

--- a/templates/showcase.html
+++ b/templates/showcase.html
@@ -6,12 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Showcase - Personal Portfolio One Page Bulma Theme</title>
     <!-- Bulma Version 0.8.x-->
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.8.0/css/bulma.min.css"
-      integrity="sha256-vK3UTo/8wHbaUn+dTQD0X6dzidqc5l7gczvH+Bnowwk="
-      crossorigin="anonymous"
-    />
+    <link rel="stylesheet" href="https://unpkg.com/bulma@0.8.0/css/bulma.min.css" />
     <link rel="stylesheet" type="text/css" href="../css/showcase.css" />
     <script
       src="https://kit.fontawesome.com/2828f7885a.js"


### PR DESCRIPTION
3 of the templates were using a broken 0.8 bulma.css link so I replaced it with a working version