### PR TITLE
Feature/remove instance of open sans

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1,5 +1,5 @@
 html, body {
-  font-family: 'Open Sans', serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   font-size: 16px;
   line-height: 1.5;
   height: 100%;

--- a/css/blog.css
+++ b/css/blog.css
@@ -1,5 +1,5 @@
 html,body {
-  font-family: 'Open Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   font-size: 14px;
   background: #F0F2F4;
 }

--- a/css/forum.css
+++ b/css/forum.css
@@ -1,5 +1,5 @@
 html,body {
-  font-family: 'Open Sans', serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   background: #F2F6FA;
 }
 footer {

--- a/css/hero.css
+++ b/css/hero.css
@@ -1,6 +1,6 @@
 html,body {
   background: #EFF3F4;
-  font-family: 'Open Sans', serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 .hero-body .container {
   max-width: 700px;

--- a/css/inbox.css
+++ b/css/inbox.css
@@ -1,5 +1,5 @@
 html,body {
-  font-family: 'Open Sans', serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   font-size: 14px;
   line-height: 1.5;
   height: 100%;

--- a/css/index.css
+++ b/css/index.css
@@ -1,5 +1,5 @@
 html, body {
-  font-family: 'Open Sans', serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   background: #F0F2F4;
 }
 .card {

--- a/css/landing.css
+++ b/css/landing.css
@@ -1,5 +1,5 @@
 html,body {
-  font-family: 'Open Sans', serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 .hero.is-info {
   background: linear-gradient(

--- a/index.css
+++ b/index.css
@@ -1,5 +1,5 @@
 html, body {
-  font-family: 'Open Sans', serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   background:  #DCDCDC;
 }
 .card {


### PR DESCRIPTION
This PR follows on from https://github.com/BulmaTemplates/bulma-templates/pull/126.

The Google font import has been removed but the CSS is still trying to use that font family. Before defaulting to a Times New Roman, which doesn't look great:

<img width="1328" alt="Screenshot 2019-10-25 at 17 02 41" src="https://user-images.githubusercontent.com/16327542/67586866-87d47880-f74a-11e9-870b-8f331183c890.png">

This PR replaces all instances of 'Open Sans' with a system font stack, using the users system default if available, with a sans-serif fallback. This quickly loads the best possible, web-safe font. This produces the following result using Chrome on MacOS:

<img width="1315" alt="Screenshot 2019-10-25 at 17 09 48" src="https://user-images.githubusercontent.com/16327542/67586937-b4889000-f74a-11e9-8dd9-f1bd4143f353.png">
