### PR TITLE
Remove deprecated JQuery event-aliases

### DIFF
--- a/js/showcase.js
+++ b/js/showcase.js
@@ -47,11 +47,11 @@ function scrollFunction() {
 }
 
 // Preloader
-$(document).ready(function($) {
+$(document).on("ready", function($) {
   $(".preloader-wrapper").fadeOut();
   $("body").removeClass("preloader-site");
 });
-$(window).load(function() {
+$(window).on("load", function() {
   var Body = $("body");
   Body.addClass("preloader-site");
 });

--- a/js/showcase.js
+++ b/js/showcase.js
@@ -47,7 +47,7 @@ function scrollFunction() {
 }
 
 // Preloader
-$(document).on("ready", function($) {
+$(document).ready(function($) {
   $(".preloader-wrapper").fadeOut();
   $("body").removeClass("preloader-site");
 });


### PR DESCRIPTION
Apparently the event alias like `load` were deprecated in JQuery 1.8 and using them gives a `TypeError` on Firefox:

> TypeError: a.indexOf is not a function

I'm not a JS professional, [this StackOverflow question](https://stackoverflow.com/questions/38871753/uncaught-typeerror-a-indexof-is-not-a-function-error-when-opening-new-foundat) is where I learnt about this deprecation from.