### PR TITLE
Fix image class in cards.html, minor formatting fixes

### DIFF
--- a/templates/blog.html
+++ b/templates/blog.html
@@ -21,8 +21,8 @@
         <div class="container">
             <div class="navbar-brand">
                 <a class="navbar-item" href="../">
-                        <img src="../images/bulma.png" alt="Logo">
-                    </a>
+                    <img src="../images/bulma.png" alt="Logo">
+                </a>
                 <span class="navbar-burger burger" data-target="navbarMenu">
                         <span></span>
                 <span></span>
@@ -191,14 +191,14 @@
         <!-- END ARTICLE FEED -->
         </div>
         <script async type="text/javascript" src="../js/bulma.js"></script>
-        <script src='https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/1.9.1/js/OverlayScrollbars.min.js'></script>  
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/1.9.1/js/OverlayScrollbars.min.js'></script>
         <script>
         document.addEventListener("DOMContentLoaded", function() {
         //The first argument are the elements to which the plugin shall be initialized
         //The second argument has to be at least a empty object or a object with your desired options
         OverlayScrollbars(document.querySelectorAll("body"), { });
         });
-        </script>        
+        </script>
 </body>
 
 </html>

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -63,8 +63,8 @@
         <div id="app" class="row columns is-multiline">
           <div v-for="card in cardData" key="card.id" class="column is-4">
             <div class="card large">
-              <div class="card-image is-16by9">
-                <figure class="image">
+              <div class="card-image">
+                <figure class="image is-16by9">
                   <img :src="card.image" alt="Image">
                 </figure>
               </div>

--- a/templates/tabs.html
+++ b/templates/tabs.html
@@ -197,8 +197,8 @@
                 <div class="tab-pane" id="pane-4">
                     <div class="columns is-centered">
                         <div class="column is-three-quarters">
-                            <div class='embed-container image'>
-                                <iframe src='https://player.vimeo.com/video/261794608' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+                            <div class="embed-container image">
+                                <iframe src="https://player.vimeo.com/video/261794608" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
I fixed an issue in `cards.html`, where the `is-16by9` class was not applied to the correct element, which caused the content to move as the images load in the browser. I also made a couple formatting tweaks.