### PR TITLE
Migrate Admin and Band templates from Tiles to Grid in Bulma 1.0

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -115,27 +115,27 @@
                     </div>
                 </section>
                 <section class="info-tiles">
-                    <div class="tile is-ancestor has-text-centered">
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
+                    <div class="grid has-text-centered">
+                        <div class="cell">
+                            <article class="box">
                                 <p class="title">439k</p>
                                 <p class="subtitle">Users</p>
                             </article>
                         </div>
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
+                        <div class="cell">
+                            <article class="box">
                                 <p class="title">59k</p>
                                 <p class="subtitle">Products</p>
                             </article>
                         </div>
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
+                        <div class="cell">
+                            <article class="box">
                                 <p class="title">3.4k</p>
                                 <p class="subtitle">Open Orders</p>
                             </article>
                         </div>
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
+                        <div class="cell">
+                            <article class="box">
                                 <p class="title">19</p>
                                 <p class="subtitle">Exceptions</p>
                             </article>

--- a/templates/band.html
+++ b/templates/band.html
@@ -164,9 +164,9 @@
         <div class="container has-text-centered">
             <h2 class="title">Tour Dates</h2>
 
-            <div class="tile is-ancestor">
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+            <div class="grid">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -175,8 +175,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -185,8 +185,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -195,8 +195,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -205,8 +205,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -217,9 +217,9 @@
                 </div>
             </div>
 
-            <div class="tile is-ancestor">
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+            <div class="grid">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -228,8 +228,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -238,8 +238,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -248,8 +248,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>
@@ -258,8 +258,8 @@
                         <a class="button">Buy Tickets</a>
                     </article>
                 </div>
-                <div class="tile is-parent">
-                    <article class="tile is-child box">
+                <div class="cell">
+                    <article class="box">
                         <figure class="image">
                             <img src="https://images.pexels.com/photos/374710/pexels-photo-374710.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260">
                         </figure>


### PR DESCRIPTION
Currently, Admin and Band templates are not displayed correctly, so this migration aims to fix layout issues caused by the [outdated Tiles structure](https://bulma.io/documentation/start/migrating-to-v1/#breaking-changes). But Aside and Hero templates(which also use Tiles) were not migrated, as I was unable to find `is-vertical` in Bulma 1.0.